### PR TITLE
Properly handle GCMRegistrar errors

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -39,8 +39,10 @@
 			<uses-permission android:name="android.permission.WAKE_LOCK" />
 			<uses-permission android:name="android.permission.VIBRATE"/>
 			<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
-			<permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE" android:protectionLevel="signature" />
-			<uses-permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE" />
+		<!--	<permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE" android:protectionLevel="signature" /> -->
+                        <permission android:name="com.vitalreactor.orchestra2.permission.C2D_MESSAGE" android:protectionLevel="signature" />
+		<!--	<uses-permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE" /> -->
+                        <uses-permission android:name="com.vitalreactor.orchestra2.permission.C2D_MESSAGE" />
 		</config-file>
 
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">

--- a/plugin.xml
+++ b/plugin.xml
@@ -39,10 +39,8 @@
 			<uses-permission android:name="android.permission.WAKE_LOCK" />
 			<uses-permission android:name="android.permission.VIBRATE"/>
 			<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
-		<!--	<permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE" android:protectionLevel="signature" /> -->
-                        <permission android:name="com.vitalreactor.orchestra2.permission.C2D_MESSAGE" android:protectionLevel="signature" />
-		<!--	<uses-permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE" /> -->
-                        <uses-permission android:name="com.vitalreactor.orchestra2.permission.C2D_MESSAGE" />
+			<permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE" android:protectionLevel="signature" />
+			<uses-permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE" />
 		</config-file>
 
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">

--- a/src/android/com/plugin/gcm/GCMIntentService.java
+++ b/src/android/com/plugin/gcm/GCMIntentService.java
@@ -114,7 +114,7 @@ public class GCMIntentService extends GCMBaseIntentService {
 		}
 
 		mNotificationManager.notify((String) appName, notId, mBuilder.build());
-		
+
 	}
 
 	public static void cancelNotification(Context context)
@@ -136,6 +136,7 @@ public class GCMIntentService extends GCMBaseIntentService {
 	@Override
 	public void onError(Context context, String errorId) {
 		Log.e(TAG, "onError - errorId: " + errorId);
+                NotificationService.getInstance(context).onRegistrationError(errorId);
 	}
 
 }

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -74,6 +74,8 @@ public class NotificationService {
 
     private String mRegistrationID = null;
 
+    private String mRegistrationErrorId = null;
+
     private List<JSONObject> mNotifications = new ArrayList<JSONObject>();
 
     private boolean mForeground = false;
@@ -203,6 +205,17 @@ public class NotificationService {
     private void notifyRegisteredToAllWebViews() {
         for (WebViewReference webViewReference : mWebViewReferences) {
             webViewReference.notifyRegistered();
+        }
+    }
+
+    public void onRegistrationError(String errorId) {
+        mRegistrationErrorId = errorId;
+        notifyRegistrationErrorToAllWebViews();
+    }
+
+    private void notifyRegistrationErrorToAllWebViews() {
+        for (WebViewReference webViewReference : mWebViewReferences) {
+            webViewReference.notifyRegistrationError();
         }
     }
 
@@ -512,6 +525,15 @@ public class NotificationService {
                 getRegisterCallBack().success(mNotificationService.mRegistrationID);
             } else {
                 Log.v(TAG, "No Register callback - webview: " + getWebView());
+            }
+        }
+
+        public void notifyRegistrationError() {
+            Log.v(TAG,
+                  "GCM Registration Failed for webview " + getWebView());
+            if (getRegisterCallBack() != null){
+                setNotifiedOfRegistered(false);
+                getRegisterCallBack().error(mNotificationService.mRegistrationErrorId);
             }
         }
 


### PR DESCRIPTION
GCM Registration errors were being logged to the device log, but not propagated to the app via the passed in error handler.  Added handlers to populate the error callback.  