### PR TITLE
Next pr

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -39,8 +39,8 @@
 			<uses-permission android:name="android.permission.WAKE_LOCK" />
 			<uses-permission android:name="android.permission.VIBRATE"/>
 			<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
-			<permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE" android:protectionLevel="signature" />
-			<uses-permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE" />
+			<permission android:name="com.vitalreactor.orchestra2.permission.C2D_MESSAGE" android:protectionLevel="signature" />
+			<uses-permission android:name="com.vitalreactor.orchestra2.permission.C2D_MESSAGE" />
 		</config-file>
 
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">

--- a/plugin.xml
+++ b/plugin.xml
@@ -39,8 +39,9 @@
 			<uses-permission android:name="android.permission.WAKE_LOCK" />
 			<uses-permission android:name="android.permission.VIBRATE"/>
 			<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
-			<permission android:name="com.vitalreactor.orchestra2.permission.C2D_MESSAGE" android:protectionLevel="signature" />
-			<uses-permission android:name="com.vitalreactor.orchestra2.permission.C2D_MESSAGE" />
+                        <!-- this is not granting the appropriate permissions for re-try -->
+			<permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE" android:protectionLevel="signature" />
+			<uses-permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE" />
 		</config-file>
 
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">

--- a/plugin.xml
+++ b/plugin.xml
@@ -61,7 +61,7 @@
 		<source-file src="src/android/com/plugin/gcm/PushHandlerActivity.java" target-dir="src/com/plugin/gcm/" />
 		<source-file src="src/android/com/plugin/gcm/PushPlugin.java" target-dir="src/com/plugin/gcm/" />
                 <source-file src="src/android/com/plugin/gcm/NotificationService.java" target-dir="src/com/plugin/gcm/" />
-                <source-file src="src/android/com/plugin/gcm/AsyncRegistrationInterface.java" target="src/com/plugin/gcm/" />
+                <source-file src="src/android/com/plugin/gcm/AsyncRegistrationInterface.java" target-dir="src/com/plugin/gcm/" />
 
 	</platform>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -49,7 +49,7 @@
 				<intent-filter>
 					<action android:name="com.google.android.c2dm.intent.RECEIVE" />
 					<action android:name="com.google.android.c2dm.intent.REGISTRATION" />
-					<category android:name="com.vitalreactor.orchestra2" />
+					<category android:name="$PACKAGE_NAME" />
 				</intent-filter>
 			</receiver>
 			<service android:name="com.plugin.gcm.GCMIntentService" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -60,7 +60,8 @@
 		<source-file src="src/android/com/plugin/gcm/GCMIntentService.java" target-dir="src/com/plugin/gcm/" />
 		<source-file src="src/android/com/plugin/gcm/PushHandlerActivity.java" target-dir="src/com/plugin/gcm/" />
 		<source-file src="src/android/com/plugin/gcm/PushPlugin.java" target-dir="src/com/plugin/gcm/" />
-    <source-file src="src/android/com/plugin/gcm/NotificationService.java" target-dir="src/com/plugin/gcm/" />
+                <source-file src="src/android/com/plugin/gcm/NotificationService.java" target-dir="src/com/plugin/gcm/" />
+                <source-file src="src/android/com/plugin/gcm/AsyncRegistrationInterface.java" target="src/com/plugin/gcm/" />
 
 	</platform>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -49,7 +49,7 @@
 				<intent-filter>
 					<action android:name="com.google.android.c2dm.intent.RECEIVE" />
 					<action android:name="com.google.android.c2dm.intent.REGISTRATION" />
-					<category android:name="$PACKAGE_NAME" />
+					<category android:name="com.vitalreactor.orchestra2" />
 				</intent-filter>
 			</receiver>
 			<service android:name="com.plugin.gcm.GCMIntentService" />

--- a/src/android/com/plugin/gcm/AsyncRegistrationInterface.java
+++ b/src/android/com/plugin/gcm/AsyncRegistrationInterface.java
@@ -1,0 +1,6 @@
+package com.plugin.gcm;
+
+public interface AsyncRegistrationInterface{
+    public void onRegistrationSuccess(String registrationId);
+    public void onRegistrationFailure(String errorId);
+}

--- a/src/android/com/plugin/gcm/AsyncRegistrationInterface.java
+++ b/src/android/com/plugin/gcm/AsyncRegistrationInterface.java
@@ -1,6 +1,9 @@
 package com.plugin.gcm;
 
+import org.json.JSONArray;
+
 public interface AsyncRegistrationInterface{
+    public boolean handleRegister(JSONArray data);
     public void onRegistrationSuccess(String registrationId);
     public void onRegistrationFailure(String errorId);
 }

--- a/src/android/com/plugin/gcm/GCMIntentService.java
+++ b/src/android/com/plugin/gcm/GCMIntentService.java
@@ -130,6 +130,7 @@ public class GCMIntentService extends GCMBaseIntentService {
     @Override
     public void onError(Context context, String errorId) {
         Log.e(TAG, "onError - errorId: " + errorId);
+        NotificationService.getInstance(context).onRegistrationError(errorId);
     }
 
 }

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -437,7 +437,9 @@ public class NotificationService {
                 PluginResult result =
                     new PluginResult(PluginResult.Status.OK,
                                      mNotificationService.mRegistrationID);
-                //result.setKeepCallback(true);
+
+                result.setKeepCallback(false);
+
                 callBack.sendPluginResult(result);
             } else {
                 Log.v(TAG, "No Register callback - webview: " + getWebView());
@@ -457,7 +459,7 @@ public class NotificationService {
                     new PluginResult(PluginResult.Status.ERROR,
                                      mNotificationService.mRegistrationErrorId);
 
-                //result.setKeepCallback(true);
+                result.setKeepCallback(false);
 
                 callBack.sendPluginResult(result);
             }else{

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -515,6 +515,11 @@ public class NotificationService {
         }
 
         public void setRegisterCallBack(CallbackContext callBack) {
+            Log.v(TAG, "Setting Register callback: "
+                  + callBack.toString()
+                  + " for webview: "
+                  + getWebView());
+
             mRegisterCallBack = callBack;
         }
 

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -99,6 +99,7 @@ public class NotificationService {
         }
     }
 
+    /*
     public void addRegisterCallBack(CordovaWebView webView, CallbackContext callBack) {
         WebViewReference webViewReference = getWebViewReference(webView);
         webViewReference.setRegisterCallBack(callBack);
@@ -108,6 +109,12 @@ public class NotificationService {
         } else {
             registerDevice();
         }
+        } */
+
+    public void addRegistrationHandler(CordovaWebView webView, AsyncRegistrationInterface ari){
+        WebViewReference webViewReference = getWebViewReference(webView);
+        webViewReference.setAsyncHandler(ari);
+
     }
 
     public void addNotificationForegroundCallBack(CordovaWebView webView,
@@ -383,6 +390,8 @@ public class NotificationService {
 
         private CallbackContext mRegisterCallBack;
 
+        private AsyncRegistrationInterface asyncHandler;
+
         private CallbackContext mNotificationForegroundCallBack;
 
         private CallbackContext mNotificationBackgroundCallBack;
@@ -424,6 +433,8 @@ public class NotificationService {
             return mNotifications.contains(notification);
         }
 
+        /*
+
         public void notifyRegistered() {
             if (hasNotifiedOfRegistered()) {
                 Log.v(TAG,
@@ -444,27 +455,61 @@ public class NotificationService {
             } else {
                 Log.v(TAG, "No Register callback - webview: " + getWebView());
             }
+            } */
+
+
+        public void notifyRegistered() {
+            if (hasNotifiedOfRegistered()) {
+                Log.v(TAG,
+                      "notifyRegistered() - Webview already notified of registration. skipping callback. webview: "
+                      + getWebView());
+                return;
+            }
+            Log.v(TAG,
+                  "GCM Registration Failed webview: " + getWebView());
+            AsyncRegistrationInterface handler = getAsyncHandler();
+            if (handler != null){
+                Log.v(TAG, "handler found, sending registration id "
+                      + mNotificationService.mRegistrationErrorId
+                      + "to handler: " + handler.toString());
+
+                handler.onRegistrationSuccess(mNotificationService.mRegistrationID);
+
+                //PluginResult result =
+                //    new PluginResult(PluginResult.Status.ERROR,
+                //                     mNotificationService.mRegistrationErrorId);
+                //
+                //result.setKeepCallback(false);
+
+                //callBack.sendPluginResult(result);
+            }else{
+                Log.v(TAG,
+                      "registration error -> No Register handler - webview: "
+                      + getWebView());
+            }
         }
 
         public void notifyRegistrationError() {
             Log.v(TAG,
                   "GCM Registration Failed for webview: " + getWebView());
-            CallbackContext callBack = getRegisterCallBack();
-            if (callBack != null){
-                Log.v(TAG, "CallbackContext found, sending error "
+            AsyncRegistrationInterface handler = getAsyncHandler();
+            if (handler != null){
+                Log.v(TAG, "handler found, sending error "
                       + mNotificationService.mRegistrationErrorId
-                      + "to callback: " + getRegisterCallBack().getCallbackId());
+                      + "to handler: " + handler.toString());
 
-                PluginResult result =
-                    new PluginResult(PluginResult.Status.ERROR,
-                                     mNotificationService.mRegistrationErrorId);
+                handler.onRegistrationFailure(mNotificationService.mRegistrationErrorId);
 
-                result.setKeepCallback(false);
+                //PluginResult result =
+                //    new PluginResult(PluginResult.Status.ERROR,
+                //                     mNotificationService.mRegistrationErrorId);
+                //
+                //result.setKeepCallback(false);
 
-                callBack.sendPluginResult(result);
+                //callBack.sendPluginResult(result);
             }else{
                 Log.v(TAG,
-                      "registration error -> No Register callback - webview: "
+                      "registration error -> No Register handler - webview: "
                       + getWebView());
             }
         }
@@ -534,6 +579,14 @@ public class NotificationService {
                   + getWebView());
 
             mRegisterCallBack = callBack;
+        }
+
+        public void setAsyncHandler(AsyncRegistrationInterface ari){
+            asyncHandler = ari;
+        }
+
+        public AsynRegistrationInterface getAsyncHandler(){
+            return asyncHandler;
         }
 
         public CallbackContext getRegisterCallBack() {

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -448,7 +448,7 @@ public class NotificationService {
                       + mNotificationService.mRegistrationErrorId
                       + "to callback: " + getRegisterCallBack().getCallbackId());
                 PluginResult errorResult = new PluginResult(PluginResult.Status.ERROR,
-                                                            mRegistrationErrorId);
+                                                            mNotificationService.mRegistrationErrorId);
 
                 errorResult.setKeepCallback(true);
 

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -448,7 +448,8 @@ public class NotificationService {
                 getRegisterCallBack().error(mNotificationService.mRegistrationErrorId);
             }else{
                 Log.v(TAG,
-                      "registration error -> No Register callback - webview: " getWebView();
+                      "registration error -> No Register callback - webview: "
+                      + getWebView());
             }
         }
 

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -444,7 +444,8 @@ public class NotificationService {
             Log.v(TAG,
                   "GCM Registration Failed for webview " + getWebView());
             if (getRegisterCallBack() != null){
-                setNotifiedOfRegistered(false);
+                Log.v(TAG, "CallbackContext found, sending error "
+                      + "-> callback: " + getRegisterCallBack().toString());
                 getRegisterCallBack().error(mNotificationService.mRegistrationErrorId);
             }else{
                 Log.v(TAG,

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -431,10 +431,14 @@ public class NotificationService {
                                 + getWebView());
                 return;
             }
-
-            if (getRegisterCallBack() != null) {
+            CallbackContext callBack = getRegisterCallBack();
+            if (callBack != null) {
                 setNotifiedOfRegistered(true);
-                getRegisterCallBack().success(mNotificationService.mRegistrationID);
+                PluginResult result =
+                    new PluginResult(PluginResult.Status.OK,
+                                     mNotificationService.mRegistrationID);
+                //result.setKeepCallback(true);
+                callBack.sendPluginResult(result);
             } else {
                 Log.v(TAG, "No Register callback - webview: " + getWebView());
             }
@@ -443,11 +447,19 @@ public class NotificationService {
         public void notifyRegistrationError() {
             Log.v(TAG,
                   "GCM Registration Failed for webview: " + getWebView());
-            if (getRegisterCallBack() != null){
+            CallbackContext callBack = getRegisterCallBack();
+            if (callBack != null){
                 Log.v(TAG, "CallbackContext found, sending error "
                       + mNotificationService.mRegistrationErrorId
                       + "to callback: " + getRegisterCallBack().getCallbackId());
-                getRegisterCallBack().error(mNotificationService.mRegistrationErrorId);
+
+                PluginResult result =
+                    new PluginResult(PluginResult.Status.ERROR,
+                                     mNotificationService.mRegistrationErrorId);
+
+                //result.setKeepCallback(true);
+
+                callBack.sendPluginResult(result);
             }else{
                 Log.v(TAG,
                       "registration error -> No Register callback - webview: "

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -116,6 +116,12 @@ public class NotificationService {
         WebViewReference webViewReference = getWebViewReference(webView);
         webViewReference.setAsyncHandler(ari);
 
+        if (isRegistered()) {
+            webViewReference.notifyRegistered();
+        } else {
+            registerDevice();
+        }
+
     }
 
     public void addNotificationForegroundCallBack(CordovaWebView webView,

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -447,7 +447,7 @@ public class NotificationService {
                 Log.v(TAG, "CallbackContext found, sending error "
                       + mNotificationService.mRegistrationErrorId
                       + "to callback: " + getRegisterCallBack().getCallbackId());
-                getRegisterCallBack().success(mNotificationService.mRegistrationErrorId);
+                getRegisterCallBack().error(mNotificationService.mRegistrationErrorId);
             }else{
                 Log.v(TAG,
                       "registration error -> No Register callback - webview: "

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -447,10 +447,13 @@ public class NotificationService {
                 Log.v(TAG, "CallbackContext found, sending error "
                       + mNotificationService.mRegistrationErrorId
                       + "to callback: " + getRegisterCallBack().getCallbackId());
+                PluginResult errorResult = new PluginResult(PluginResult.Status.ERROR,
+                                                            mRegistrationErrorId);
+
+                errorResult.setKeepCallback(true);
 
                 getRegisterCallBack()
-                .sendPluginResult(new PluginResult(PluginResult.Status.ERROR,
-                                                   "Registration Failed"));
+                    .sendPluginResult(errorResult);
             }else{
                 Log.v(TAG,
                       "registration error -> No Register callback - webview: "

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -71,6 +71,8 @@ public class NotificationService {
 
     private String mRegistrationID = null;
 
+    private String mRegistrationErrorId = null;
+
     private List<JSONObject> mNotifications = new ArrayList<JSONObject>();
 
     private boolean mForeground = false;
@@ -184,6 +186,17 @@ public class NotificationService {
     private void notifyRegisteredToAllWebViews() {
         for (WebViewReference webViewReference : mWebViewReferences) {
             webViewReference.notifyRegistered();
+        }
+    }
+
+    public void onRegistrationError(String errorId) {
+        mRegistrationErrorId = errorId;
+        notifyRegistrationErrorToAllWebViews();
+    }
+
+    private void notifyRegistrationErrorToAllWebViews() {
+        for (WebViewReference webViewReference : mWebViewReferences) {
+            webViewReference.notifyRegistrationError();
         }
     }
 
@@ -424,6 +437,18 @@ public class NotificationService {
                 getRegisterCallBack().success(mNotificationService.mRegistrationID);
             } else {
                 Log.v(TAG, "No Register callback - webview: " + getWebView());
+            }
+        }
+
+        public void notifyRegistrationError() {
+            Log.v(TAG,
+                  "GCM Registration Failed for webview " + getWebView());
+            if (getRegisterCallBack() != null){
+                setNotifiedOfRegistered(false);
+                getRegisterCallBack().error(mNotificationService.mRegistrationErrorId);
+            }else{
+                Log.v(TAG,
+                      "registration error -> No Register callback - webview: " getWebView();
             }
         }
 

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -1,5 +1,6 @@
 package com.plugin.gcm;
 
+
 import android.app.NotificationManager;
 
 import com.google.android.gcm.GCMRegistrar;
@@ -585,7 +586,7 @@ public class NotificationService {
             asyncHandler = ari;
         }
 
-        public AsynRegistrationInterface getAsyncHandler(){
+        public AsyncRegistrationInterface getAsyncHandler(){
             return asyncHandler;
         }
 

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -478,7 +478,7 @@ public class NotificationService {
             AsyncRegistrationInterface handler = getAsyncHandler();
             if (handler != null){
                 Log.v(TAG, "handler found, sending registration id "
-                      + mNotificationService.mRegistrationErrorId
+                      + mNotificationService.mRegistrationID
                       + "to handler: " + handler.toString());
 
                 handler.onRegistrationSuccess(mNotificationService.mRegistrationID);

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -442,7 +442,7 @@ public class NotificationService {
 
         public void notifyRegistrationError() {
             Log.v(TAG,
-                  "GCM Registration Failed for webview " + getWebView());
+                  "GCM Registration Failed for webview: " + getWebView());
             if (getRegisterCallBack() != null){
                 Log.v(TAG, "CallbackContext found, sending error "
                       + mNotificationService.mRegistrationErrorId

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -446,7 +446,7 @@ public class NotificationService {
             if (getRegisterCallBack() != null){
                 Log.v(TAG, "CallbackContext found, sending error "
                       + mNotificationService.mRegistrationErrorId
-                      + "to callback: " + getRegisterCallBack().toString());
+                      + "to callback: " + getRegisterCallBack().getCallbackId());
 
                 getRegisterCallBack()
                 .sendPluginResult(new PluginResult(PluginResult.Status.ERROR,

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -100,17 +100,6 @@ public class NotificationService {
         }
     }
 
-    /*
-    public void addRegisterCallBack(CordovaWebView webView, CallbackContext callBack) {
-        WebViewReference webViewReference = getWebViewReference(webView);
-        webViewReference.setRegisterCallBack(callBack);
-
-        if (isRegistered()) {
-            webViewReference.notifyRegistered();
-        } else {
-            registerDevice();
-        }
-        } */
 
     public void addRegistrationHandler(CordovaWebView webView, AsyncRegistrationInterface ari){
         WebViewReference webViewReference = getWebViewReference(webView);
@@ -441,29 +430,6 @@ public class NotificationService {
             return mNotifications.contains(notification);
         }
 
-        /*
-
-        public void notifyRegistered() {
-            if (hasNotifiedOfRegistered()) {
-                Log.v(TAG,
-                        "notifyRegistered() - Webview already notified of registration. skipping callback. webview: "
-                                + getWebView());
-                return;
-            }
-            CallbackContext callBack = getRegisterCallBack();
-            if (callBack != null) {
-                setNotifiedOfRegistered(true);
-                PluginResult result =
-                    new PluginResult(PluginResult.Status.OK,
-                                     mNotificationService.mRegistrationID);
-
-                result.setKeepCallback(false);
-
-                callBack.sendPluginResult(result);
-            } else {
-                Log.v(TAG, "No Register callback - webview: " + getWebView());
-            }
-            } */
 
 
         public void notifyRegistered() {
@@ -483,13 +449,7 @@ public class NotificationService {
 
                 handler.onRegistrationSuccess(mNotificationService.mRegistrationID);
 
-                //PluginResult result =
-                //    new PluginResult(PluginResult.Status.ERROR,
-                //                     mNotificationService.mRegistrationErrorId);
-                //
-                //result.setKeepCallback(false);
 
-                //callBack.sendPluginResult(result);
             }else{
                 Log.v(TAG,
                       "registration error -> No Register handler - webview: "
@@ -508,13 +468,7 @@ public class NotificationService {
 
                 handler.onRegistrationFailure(mNotificationService.mRegistrationErrorId);
 
-                //PluginResult result =
-                //    new PluginResult(PluginResult.Status.ERROR,
-                //                     mNotificationService.mRegistrationErrorId);
-                //
-                //result.setKeepCallback(false);
 
-                //callBack.sendPluginResult(result);
             }else{
                 Log.v(TAG,
                       "registration error -> No Register handler - webview: "

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -448,7 +448,9 @@ public class NotificationService {
                       + mNotificationService.mRegistrationErrorId
                       + "to callback: " + getRegisterCallBack().toString());
 
-                getRegisterCallBack().error(mNotificationService.mRegistrationErrorId);
+                getRegisterCallBack()
+                .sendPluginResult(new PluginResult(PluginResult.Status.ERROR,
+                                                   "Registration Failed"));
             }else{
                 Log.v(TAG,
                       "registration error -> No Register callback - webview: "

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -117,6 +117,7 @@ public class NotificationService {
         webViewReference.setAsyncHandler(ari);
 
         if (isRegistered()) {
+            Log.v(TAG, "isRegistered() true!!");
             webViewReference.notifyRegistered();
         } else {
             registerDevice();

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -447,13 +447,7 @@ public class NotificationService {
                 Log.v(TAG, "CallbackContext found, sending error "
                       + mNotificationService.mRegistrationErrorId
                       + "to callback: " + getRegisterCallBack().getCallbackId());
-                PluginResult errorResult = new PluginResult(PluginResult.Status.ERROR,
-                                                            mNotificationService.mRegistrationErrorId);
-
-                errorResult.setKeepCallback(true);
-
-                getRegisterCallBack()
-                    .sendPluginResult(errorResult);
+                getRegisterCallBack().success(mNotificationService.mRegistrationErrorId);
             }else{
                 Log.v(TAG,
                       "registration error -> No Register callback - webview: "

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -467,7 +467,7 @@ public class NotificationService {
                 return;
             }
             Log.v(TAG,
-                  "GCM Registration Failed webview: " + getWebView());
+                  "GCM Registration webview: " + getWebView());
             AsyncRegistrationInterface handler = getAsyncHandler();
             if (handler != null){
                 Log.v(TAG, "handler found, sending registration id "

--- a/src/android/com/plugin/gcm/NotificationService.java
+++ b/src/android/com/plugin/gcm/NotificationService.java
@@ -445,7 +445,9 @@ public class NotificationService {
                   "GCM Registration Failed for webview " + getWebView());
             if (getRegisterCallBack() != null){
                 Log.v(TAG, "CallbackContext found, sending error "
-                      + "-> callback: " + getRegisterCallBack().toString());
+                      + mNotificationService.mRegistrationErrorId
+                      + "to callback: " + getRegisterCallBack().toString());
+
                 getRegisterCallBack().error(mNotificationService.mRegistrationErrorId);
             }else{
                 Log.v(TAG,

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -34,6 +34,8 @@ public class PushPlugin extends CordovaPlugin {
 
   public static final String GCM_SENDER_ID = "gcm_senderid";
 
+  private CallbackContext registrationCallback;
+
   public void initialize(CordovaInterface cordova, CordovaWebView webView) {
     super.initialize(cordova, webView);
 
@@ -63,6 +65,7 @@ public class PushPlugin extends CordovaPlugin {
 
     private boolean handleRegister(JSONArray data, CallbackContext callbackContext) {
     try {
+
       JSONObject jo = data.getJSONObject(0);
 
       String senderID = (String) jo.get(SENDER_ID);
@@ -112,14 +115,17 @@ public class PushPlugin extends CordovaPlugin {
 
         Log.v(TAG, "handleRegister -> data: " + data);
 
+        //need to keep a reference hanging around to the callback
+        this.registrationCallback = callbackContext;
+
         PluginResult temp = new PluginResult(PluginResult.Status.NO_RESULT);
 
         temp.setKeepCallback(true);
 
-        callbackContext.sendPluginResult(temp);
+        this.registrationCallback.sendPluginResult(temp);
 
         this.cordova.getThreadPool()
-            .execute(new RegistrationRunnable(data, callbackContext));
+            .execute(new RegistrationRunnable(data, this.registrationCallback));
 
         result = true;
     }

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -91,8 +91,8 @@ public class PushPlugin extends CordovaPlugin {
   }
 
     class RegistrationRunnable implements Runnable{
-        private static JSONArray data;
-        private static CallbackContext callbackContext;
+        private JSONArray data;
+        private CallbackContext callbackContext;
 
         RegistrationRunnable(JSONArray data, CallbackContext callbackContext){
             this.data = data;

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -126,7 +126,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
         //need to keep a reference hanging around to the callback
         this.registrationCallback = callbackContext;
 
-        PluginResult temp = new PluginResult(PluginResult.Status.NO_RESULT);
+        PluginResult temp = new PluginResult(PluginResult.Status.OK, "INITIALIZE");
 
         temp.setKeepCallback(true);
 

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -33,21 +33,25 @@ public class PushPlugin extends CordovaPlugin {
 
   public static final String GCM_SENDER_ID = "gcm_senderid";
 
+  private static NotificationService service;
+
   public void initialize(CordovaInterface cordova, CordovaWebView webView) {
     super.initialize(cordova, webView);
 
     LOG.setLogLevel(LOG.VERBOSE);
 
-    readSenderIdFromCordovaConfig();
+    Context appContext = getApplicationContext();
+
+    service = NotificationService.getInstance(appContext);
+
+    readSenderIdFromCordovaConfig(service);
   }
 
-  private void readSenderIdFromCordovaConfig() {
+  private void readSenderIdFromCordovaConfig(NotificationService service) {
     Bundle extras = cordova.getActivity().getIntent().getExtras();
     if(extras.containsKey(GCM_SENDER_ID)) {
       String senderID = extras.getString(GCM_SENDER_ID);
-      NotificationService
-      .getInstance(getApplicationContext())
-      .setSenderID(senderID);
+      service.setSenderID(senderID);
     }
   }
 
@@ -66,19 +70,17 @@ public class PushPlugin extends CordovaPlugin {
 
       String senderID = (String) jo.get(SENDER_ID);
 
+      Context appContext = getApplicationContext();
+
+      //NotificationService service = NotificationService.getInstance(appContext);
+
       if(senderID != null && senderID.trim().length() > 0) {
-        NotificationService
-        .getInstance(getApplicationContext())
-        .setSenderID(senderID);
+        service.setSenderID(senderID);
       }
 
-      NotificationService
-      .getInstance(getApplicationContext())
-      .registerWebView(this.webView);
+      service.registerWebView(this.webView);
 
-      NotificationService
-      .getInstance(getApplicationContext())
-      .addRegisterCallBack(this.webView, callbackContext);
+      service.addRegisterCallBack(this.webView, callbackContext);
 
       return true;
 
@@ -147,9 +149,9 @@ public class PushPlugin extends CordovaPlugin {
   private boolean handleUnRegister(JSONArray data, CallbackContext callbackContext) {
     Log.v(TAG, "handleUnRegister() -> data: " + data);
 
-    NotificationService
-    .getInstance(getApplicationContext())
-    .unRegister();
+    //NotificationService
+    //.getInstance(getApplicationContext())
+    service.unRegister();
 
     callbackContext.success();
     return true;
@@ -158,9 +160,9 @@ public class PushPlugin extends CordovaPlugin {
   private boolean handleOnMessageForeground(JSONArray data, CallbackContext callbackContext) {
     Log.v(TAG, "handleOnMessageForeground() -> data: " + data);
 
-    NotificationService
-    .getInstance(getApplicationContext())
-    .addNotificationForegroundCallBack(this.webView, callbackContext);
+    //NotificationService
+    //.getInstance(getApplicationContext())
+    service.addNotificationForegroundCallBack(this.webView, callbackContext);
 
     return true;
   }
@@ -168,9 +170,9 @@ public class PushPlugin extends CordovaPlugin {
   private boolean handleOnMessageBackground(JSONArray data, CallbackContext callbackContext) {
     Log.v(TAG, "handleOnMessageBackground() -> data: " + data);
 
-    NotificationService
-    .getInstance(getApplicationContext())
-    .addNotificationBackgroundCallBack(this.webView, callbackContext);
+    //NotificationService
+    //.getInstance(getApplicationContext())
+    service.addNotificationBackgroundCallBack(this.webView, callbackContext);
 
     return true;
   }
@@ -181,9 +183,9 @@ public class PushPlugin extends CordovaPlugin {
 
     Log.v(TAG, "onPause() -> webView: " + webView);
 
-    NotificationService
-    .getInstance(getApplicationContext())
-    .setForeground(false);
+    //NotificationService
+    //.getInstance(getApplicationContext())
+    service.setForeground(false);
   }
 
   @Override
@@ -192,9 +194,9 @@ public class PushPlugin extends CordovaPlugin {
 
     Log.v(TAG, "onResume() -> webView: " + webView);
 
-    NotificationService
-    .getInstance(getApplicationContext())
-    .setForeground(true);
+    //NotificationService
+    //.getInstance(getApplicationContext())
+    service.setForeground(true);
   }
 
 
@@ -202,9 +204,9 @@ public class PushPlugin extends CordovaPlugin {
 
     Log.v(TAG, "onDestroy() -> webView: " + webView);
 
-    NotificationService
-    .getInstance(getApplicationContext())
-    .removeWebView(this.webView);
+    //NotificationService
+    //.getInstance(getApplicationContext())
+    service.removeWebView(this.webView);
 
     super.onDestroy();
   }

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -112,9 +112,8 @@ public class PushPlugin extends CordovaPlugin {
     boolean result = false;
 
     if (REGISTER.equals(action)) {
-        this.cordova.getThreadPool()
-            .execute(
-                     new RegistrationRunnable(data, callbackContext));
+        this.cordova.getActivity()
+            .runOnUiThread(new RegistrationRunnable(data, callbackContext));
 
         result = true;
 

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -45,6 +45,7 @@ public class PushPlugin extends CordovaPlugin {
     service = NotificationService.getInstance(appContext);
 
     readSenderIdFromCordovaConfig(service);
+    Log.v(TAG, "Initialized w/ Context: " appContext.toString());
   }
 
   private void readSenderIdFromCordovaConfig(NotificationService service) {
@@ -109,11 +110,10 @@ public class PushPlugin extends CordovaPlugin {
   @Override
   public boolean execute(String action, JSONArray data, CallbackContext callbackContext) {
 
-    Log.v(TAG, "handleRegister -> data: " + data);
-
     boolean result = false;
 
     if (REGISTER.equals(action)) {
+        Log.v(TAG, "handleRegister -> data: " + data);
         this.cordova.getThreadPool()
             .execute(new RegistrationRunnable(data, callbackContext));
 

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -178,8 +178,8 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
 
   @Override
   public void onRegistrationFailure(String errorId){
-      Log.v(TAG, "Registration Success called: "
-            + registrationId
+      Log.v(TAG, "Registration Failure called: "
+            + errorId
             + " for instance WebView "
             + this.webView.toString()
             + " callBack "

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -99,6 +99,7 @@ public class PushPlugin extends CordovaPlugin {
 
     if (REGISTER.equals(action)) {
 
+
       result = handleRegister(data, callbackContext);
 
     }

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -112,8 +112,8 @@ public class PushPlugin extends CordovaPlugin {
     boolean result = false;
 
     if (REGISTER.equals(action)) {
-        this.cordova.getActivity()
-            .runOnUiThread(new RegistrationRunnable(data, callbackContext));
+        this.cordova.getThreadPool()
+            .execute(new RegistrationRunnable(data, callbackContext));
 
         result = true;
 

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -45,7 +45,8 @@ public class PushPlugin extends CordovaPlugin {
     service = NotificationService.getInstance(appContext);
 
     readSenderIdFromCordovaConfig(service);
-    Log.v(TAG, "Initialized w/ Context: " appContext.toString());
+
+    Log.v(TAG, "Initialized w/ Context: " + appContext.toString());
   }
 
   private void readSenderIdFromCordovaConfig(NotificationService service) {

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -4,7 +4,6 @@ import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaWebView;
-import org.apache.cordova.NativeToJsMessageQueue;
 import org.apache.cordova.PluginResult;
 import org.apache.cordova.LOG;
 import org.json.JSONArray;
@@ -183,6 +182,8 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
       Log.v(TAG, "WebView message queue paused? "
             + this.webView.jsMessageQueue.getPaused());
 
+      Log.v(TAG, "CORDOVA VERSION " + this.webView.CORDOVA_VERSION);
+
       PluginResult success =
           new PluginResult(PluginResult.Status.OK, registrationId);
       success.setKeepCallback(false);
@@ -205,8 +206,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
             + this.registrationCallback.isChangingThreads());
 
 
-      Log.v(TAG, "WebView message queue paused? "
-            + this.webView.jsMessageQueue.getPaused());
+      Log.v(TAG, "CORDOVA VERSION " + this.webView.CORDOVA_VERSION);
 
       PluginResult error =
           new PluginResult(PluginResult.Status.ERROR, errorId);

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -80,7 +80,7 @@ public class PushPlugin extends CordovaPlugin {
 
       service.registerWebView(this.webView);
 
-      service.addRegisterCallBack(this.webView, this.registerCallback);
+      service.addRegisterCallBack(this.webView, this.registrationCallback);
 
       return true;
 

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -167,7 +167,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
   @Override
   public void onRegistrationSuccess(String registrationId){
 
-      final resultString = registrationID;
+      final String resultString = registrationID;
       Log.v(TAG, "Registration Success called: "
             + registrationId
             + " for instance WebView "
@@ -199,7 +199,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
   @Override
   public void onRegistrationFailure(String errorId){
 
-      final resultString = errorId;
+      final String resultString = errorId;
       Log.v(TAG, "Registration Failure called: "
             + errorId
             + " for instance WebView "

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -60,7 +60,7 @@ public class PushPlugin extends CordovaPlugin {
     return this.cordova.getActivity().getApplicationContext();
   }
 
-  private boolean handleRegister(JSONArray data, CallbackContext callbackContext) {
+    private boolean handleRegister(JSONArray data, CallbackContext callbackContext) {
     try {
       JSONObject jo = data.getJSONObject(0);
 
@@ -90,6 +90,20 @@ public class PushPlugin extends CordovaPlugin {
     }
   }
 
+    class RegistrationRunnable implements Runnable{
+        private static JSONArray data;
+        private static CallbackContext callbackContext;
+
+        RegistrationRunnable(JSONArray data, CallbackContext callbackContext){
+            this.data = data;
+            this.callbackContext = callbackContext;
+        }
+
+        public void run(){
+            PushPlugin.this.handleRegister(this.data, this.callbackContext);
+        }
+    }
+
   @Override
   public boolean execute(String action, JSONArray data, CallbackContext callbackContext) {
 
@@ -100,11 +114,7 @@ public class PushPlugin extends CordovaPlugin {
     if (REGISTER.equals(action)) {
         this.cordova.getThreadPool()
             .execute(
-               new Runnable(){
-                   public void run(){
-                     handleRegister(data, callbackContext);
-                   }
-                });
+                     new RegistrationRunnable(data, callbackContext));
 
         result = true;
 

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -126,7 +126,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
         //need to keep a reference hanging around to the callback
         this.registrationCallback = callbackContext;
 
-        PluginResult temp = new PluginResult(PluginResult.Status.OK, "INITIALIZE");
+        PluginResult temp = new PluginResult(PluginResult.Status.NO_RESULT);
 
         temp.setKeepCallback(true);
 
@@ -166,8 +166,10 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
   public void onRegistrationSuccess(String registrationId){
       Log.v(TAG, "Registration Success called: "
             + registrationId
-            + " for instance "
-            + this.toString());
+            + " for instance WebView "
+            + this.webView.toString()
+            + " callBack "
+            + this.registrationCallback.getCallbackId());
       PluginResult success =
           new PluginResult(PluginResult.Status.OK, registrationId);
       success.setKeepCallback(false);
@@ -176,10 +178,12 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
 
   @Override
   public void onRegistrationFailure(String errorId){
-      Log.v(TAG, "Registration Failure called: "
-            + errorId
-            + " for instance "
-            + this.toString());
+      Log.v(TAG, "Registration Success called: "
+            + registrationId
+            + " for instance WebView "
+            + this.webView.toString()
+            + " callBack "
+            + this.registrationCallback.getCallbackId());
       PluginResult success =
           new PluginResult(PluginResult.Status.ERROR, errorId);
       success.setKeepCallback(false);

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -170,6 +170,15 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
             + this.webView.toString()
             + " callBack "
             + this.registrationCallback.getCallbackId());
+
+      Log.v(TAG, "CallbackContext Finished? "
+            + this.registrationCallback.isFinished());
+
+      Log.v(TAG, "CallbackContext is changing threads? "
+            + this.registrationCallback.isChangingThreads());
+
+      Log.v(TAG, "WebView initialized? " + this.webView.isInitialized());
+
       PluginResult success =
           new PluginResult(PluginResult.Status.OK, registrationId);
       success.setKeepCallback(false);
@@ -184,10 +193,19 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
             + this.webView.toString()
             + " callBack "
             + this.registrationCallback.getCallbackId());
-      PluginResult success =
+
+      Log.v(TAG, "CallbackContext Finished? "
+            + this.registrationCallback.isFinished());
+
+      Log.v(TAG, "CallbackContext is changing threads? "
+            + this.registrationCallback.isChangingThreads());
+
+      Log.v(TAG, "WebView initialized? " + this.webView.isInitialized());
+
+      PluginResult error =
           new PluginResult(PluginResult.Status.ERROR, errorId);
-      success.setKeepCallback(false);
-      this.registrationCallback.sendPluginResult(success);
+      error.setKeepCallback(false);
+      this.registrationCallback.sendPluginResult(error);
   }
 
   private boolean handleUnRegister(JSONArray data, CallbackContext callbackContext) {

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -167,7 +167,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
   @Override
   public void onRegistrationSuccess(String registrationId){
 
-      final String resultString = registrationID;
+      final String resultString = registrationId;
       Log.v(TAG, "Registration Success called: "
             + registrationId
             + " for instance WebView "
@@ -189,7 +189,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
                   PluginResult success =
                       new PluginResult(PluginResult.Status.OK, resultString);
                   success.setKeepCallback(false);
-                  PushPlugun.this.registrationCallback.sendPluginResult(success);
+                  PushPlugin.this.registrationCallback.sendPluginResult(success);
               };
           });
   }

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -63,7 +63,7 @@ public class PushPlugin extends CordovaPlugin {
     return this.cordova.getActivity().getApplicationContext();
   }
 
-    private boolean handleRegister(JSONArray data, CallbackContext callbackContext) {
+    private boolean handleRegister(JSONArray data) {
     try {
 
       JSONObject jo = data.getJSONObject(0);
@@ -80,7 +80,7 @@ public class PushPlugin extends CordovaPlugin {
 
       service.registerWebView(this.webView);
 
-      service.addRegisterCallBack(this.webView, callbackContext);
+      service.addRegisterCallBack(this.webView, this.registerCallback);
 
       return true;
 
@@ -94,15 +94,13 @@ public class PushPlugin extends CordovaPlugin {
 
     class RegistrationRunnable implements Runnable{
         private JSONArray data;
-        private CallbackContext callbackContext;
 
-        RegistrationRunnable(JSONArray data, CallbackContext callbackContext){
+        RegistrationRunnable(JSONArray data){
             this.data = data;
-            this.callbackContext = callbackContext;
         }
 
         public void run(){
-            PushPlugin.this.handleRegister(this.data, this.callbackContext);
+            PushPlugin.this.handleRegister(this.data);
         }
     }
 
@@ -125,7 +123,7 @@ public class PushPlugin extends CordovaPlugin {
         this.registrationCallback.sendPluginResult(temp);
 
         this.cordova.getThreadPool()
-            .execute(new RegistrationRunnable(data, this.registrationCallback));
+            .execute(new RegistrationRunnable(data));
 
         result = true;
     }

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -152,7 +152,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
     return result;
   }
 
-  @override
+  @Override
   public void onRegistrationSuccess(String registrationId){
       PluginResult success =
           new PluginResult(PluginResult.Status.OK, registrationId);
@@ -160,13 +160,13 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
       this.registrationCallback.sendPluginResult(success);
   }
 
-    @override
-    public void onRegistrationFailure(String errorId){
-        PluginResult success =
-            new PluginResult(PluginResult.Status.ERROR, errorId);
-        success.setKeepCallback(false);
-        this.registrationCallback.sendPluginResult(success);
-    }
+  @Override
+  public void onRegistrationFailure(String errorId){
+      PluginResult success =
+          new PluginResult(PluginResult.Status.ERROR, errorId);
+      success.setKeepCallback(false);
+      this.registrationCallback.sendPluginResult(success);
+  }
 
   private boolean handleUnRegister(JSONArray data, CallbackContext callbackContext) {
     Log.v(TAG, "handleUnRegister() -> data: " + data);

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -178,13 +178,16 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
       Log.v(TAG, "CallbackContext is changing threads? "
             + this.registrationCallback.isChangingThreads());
 
+      this.cordova.getActivity().runOnUiThread(new Runnable(){
+              public void run(){
+                  this.webView.setNetworkAvailable(true);
 
-      this.webView.setNetworkAvailable(true);
-
-      PluginResult success =
-          new PluginResult(PluginResult.Status.OK, registrationId);
-      success.setKeepCallback(false);
-      this.registrationCallback.sendPluginResult(success);
+                  PluginResult success =
+                      new PluginResult(PluginResult.Status.OK, registrationId);
+                  success.setKeepCallback(false);
+                  this.registrationCallback.sendPluginResult(success);
+              };
+          });
   }
 
   @Override
@@ -202,13 +205,23 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
       Log.v(TAG, "CallbackContext is changing threads? "
             + this.registrationCallback.isChangingThreads());
 
+      this.cordova.getActivity().runOnUiThread(new Runnable(){
+              public void run(){
+                  this.webView.setNetworkAvailable(true);
 
-      this.webView.setNetworkAvailable(true);
+                  PluginResult success =
+                      new PluginResult(PluginResult.Status.OK, registrationId);
+                  success.setKeepCallback(false);
+                  this.registrationCallback.sendPluginResult(success);
+              };
+          });
 
-      PluginResult error =
-          new PluginResult(PluginResult.Status.ERROR, errorId);
-      error.setKeepCallback(false);
-      this.registrationCallback.sendPluginResult(error);
+      //this.webView.setNetworkAvailable(true);
+
+      //PluginResult error =
+      //    new PluginResult(PluginResult.Status.ERROR, errorId);
+      //error.setKeepCallback(false);
+      //this.registrationCallback.sendPluginResult(error);
   }
 
   private boolean handleUnRegister(JSONArray data, CallbackContext callbackContext) {

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -67,8 +67,6 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
     public boolean handleRegister(JSONArray data) {
     try {
 
-        //Log.v(TAG,
-        //      "Handling registration on separate thread ->" + data.toString());
 
       JSONObject jo = data.getJSONObject(0);
 
@@ -123,7 +121,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
 
         Log.v(TAG, "PushPlugin == " + this.toString());
 
-        //need to keep a reference hanging around to the callback
+        //need to keep a reference to the callback.
         this.registrationCallback = callbackContext;
 
         PluginResult temp = new PluginResult(PluginResult.Status.NO_RESULT);
@@ -132,10 +130,11 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
 
         this.registrationCallback.sendPluginResult(temp);
 
+        //Take registration off of WebCore thread
         this.cordova.getThreadPool()
             .execute(new RegistrationRunnable(data,this));
 
-        //result = handleRegister(data);
+
         result = true;
     }
     else if (ON_MESSAGE_FOREGROUND.equals(action)) {
@@ -159,7 +158,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
       callbackContext.error("Invalid action : " + action);
     }
 
-    Log.v(TAG, "Exiting Exec method: " + this.toString());
+
     return result;
   }
 
@@ -180,17 +179,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
           = new PluginResult(PluginResult.Status.OK, registrationId);
       success.setKeepCallback(false);
       this.registrationCallback.sendPluginResult(success);
-      /*
-      this.cordova.getActivity().runOnUiThread(new Runnable(){
-              public void run(){
-                  PushPlugin.this.webView.setNetworkAvailable(true);
 
-                  PluginResult success =
-                      new PluginResult(PluginResult.Status.OK, resultString);
-                  success.setKeepCallback(false);
-                  PushPlugin.this.registrationCallback.sendPluginResult(success);
-              };
-              });*/
   }
 
 
@@ -211,25 +200,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
       error.setKeepCallback(false);
       this.registrationCallback.sendPluginResult(error);
 
-      /*
-      this.cordova.getActivity().runOnUiThread(new Runnable(){
-              public void run(){
-                  PushPlugin.this.webView.setNetworkAvailable(true);
-
-                  PluginResult success =
-                      new PluginResult(PluginResult.Status.OK, resultString);
-                  success.setKeepCallback(false);
-                  PushPlugin.this.registrationCallback.sendPluginResult(success);
-              };
-              }); */
-
-      //this.webView.setNetworkAvailable(true);
-
-      //PluginResult error =
-      //    new PluginResult(PluginResult.Status.ERROR, errorId);
-      //error.setKeepCallback(false);
-      //this.registrationCallback.sendPluginResult(error);
-  }
+     }
 
   private boolean handleUnRegister(JSONArray data, CallbackContext callbackContext) {
     Log.v(TAG, "handleUnRegister() -> data: " + data);

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -179,10 +179,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
             + this.registrationCallback.isChangingThreads());
 
 
-      Log.v(TAG, "WebView message queue paused? "
-            + this.webView.jsMessageQueue.getPaused());
-
-      Log.v(TAG, "CORDOVA VERSION " + this.webView.CORDOVA_VERSION);
+      this.webView.setNetworkAvailable(true);
 
       PluginResult success =
           new PluginResult(PluginResult.Status.OK, registrationId);
@@ -206,7 +203,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
             + this.registrationCallback.isChangingThreads());
 
 
-      Log.v(TAG, "CORDOVA VERSION " + this.webView.CORDOVA_VERSION);
+      this.webView.setNetworkAvailable(true);
 
       PluginResult error =
           new PluginResult(PluginResult.Status.ERROR, errorId);

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -99,8 +99,11 @@ public class PushPlugin extends CordovaPlugin {
 
     if (REGISTER.equals(action)) {
         this.cordova.getThreadPool()
-            .execute(new Runnable(){
-                    handleRegister(data, callbackContext);
+            .execute(
+               new Runnable(){
+                   public void run(){
+                     handleRegister(data, callbackContext);
+                   }
                 });
 
         result = true;

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -162,8 +162,12 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
     return result;
   }
 
+
+
   @Override
   public void onRegistrationSuccess(String registrationId){
+
+      final resultString = registrationID;
       Log.v(TAG, "Registration Success called: "
             + registrationId
             + " for instance WebView "
@@ -180,18 +184,22 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
 
       this.cordova.getActivity().runOnUiThread(new Runnable(){
               public void run(){
-                  this.webView.setNetworkAvailable(true);
+                  PushPlugin.this.webView.setNetworkAvailable(true);
 
                   PluginResult success =
-                      new PluginResult(PluginResult.Status.OK, registrationId);
+                      new PluginResult(PluginResult.Status.OK, resultString);
                   success.setKeepCallback(false);
-                  this.registrationCallback.sendPluginResult(success);
+                  PushPlugun.this.registrationCallback.sendPluginResult(success);
               };
           });
   }
 
+
+
   @Override
   public void onRegistrationFailure(String errorId){
+
+      final resultString = errorId;
       Log.v(TAG, "Registration Failure called: "
             + errorId
             + " for instance WebView "
@@ -207,12 +215,12 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
 
       this.cordova.getActivity().runOnUiThread(new Runnable(){
               public void run(){
-                  this.webView.setNetworkAvailable(true);
+                  PushPlugin.this.webView.setNetworkAvailable(true);
 
                   PluginResult success =
-                      new PluginResult(PluginResult.Status.OK, registrationId);
+                      new PluginResult(PluginResult.Status.OK, resultString);
                   success.setKeepCallback(false);
-                  this.registrationCallback.sendPluginResult(success);
+                  PushPlugin.this.registrationCallback.sendPluginResult(success);
               };
           });
 

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -4,7 +4,7 @@ import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaWebView;
-import org.apache.cordova.CordovaWebViewImpl;
+import org.apache.cordova.NativeToJsMessageQueue;
 import org.apache.cordova.PluginResult;
 import org.apache.cordova.LOG;
 import org.json.JSONArray;
@@ -179,10 +179,9 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
       Log.v(TAG, "CallbackContext is changing threads? "
             + this.registrationCallback.isChangingThreads());
 
-      CordovaWebViewImpl wvi =
-          (CordovaWebViewImpl)this.webView;
 
-      Log.v(TAG, "WebView initialized? " + wvi.isInitialized());
+      Log.v(TAG, "WebView message queue paused? "
+            + this.webView.jsMessageQueue.getPaused());
 
       PluginResult success =
           new PluginResult(PluginResult.Status.OK, registrationId);
@@ -205,10 +204,9 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
       Log.v(TAG, "CallbackContext is changing threads? "
             + this.registrationCallback.isChangingThreads());
 
-      CordovaWebViewImpl wvi =
-          (CordovaWebViewImpl)this.webView;
 
-      Log.v(TAG, "WebView initialized? " + wvi.isInitialized());
+      Log.v(TAG, "WebView message queue paused? "
+            + this.webView.jsMessageQueue.getPaused());
 
       PluginResult error =
           new PluginResult(PluginResult.Status.ERROR, errorId);

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -98,10 +98,15 @@ public class PushPlugin extends CordovaPlugin {
     boolean result = false;
 
     if (REGISTER.equals(action)) {
+        this.cordova.getThreadPool()
+            .execute(new Runnable(){
+                    handleRegister(data, callbackContext);
+                });
+
+        result = true;
 
 
-      result = handleRegister(data, callbackContext);
-
+            //result = handleRegister(data, callbackContext);
     }
     else if (ON_MESSAGE_FOREGROUND.equals(action)) {
 

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -16,7 +16,7 @@ import android.util.Log;
 /**
 * Push Notifications Plugin
 */
-public class PushPlugin extends CordovaPlugin {
+public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterface {
 
   public static final String TAG = "PushPlugin";
 
@@ -35,6 +35,7 @@ public class PushPlugin extends CordovaPlugin {
   public static final String GCM_SENDER_ID = "gcm_senderid";
 
   private CallbackContext registrationCallback;
+
 
   public void initialize(CordovaInterface cordova, CordovaWebView webView) {
     super.initialize(cordova, webView);
@@ -80,7 +81,7 @@ public class PushPlugin extends CordovaPlugin {
 
       service.registerWebView(this.webView);
 
-      service.addRegisterCallBack(this.webView, this.registrationCallback);
+      service.addRegistrationHandler(this.webView,this);
 
       return true;
 
@@ -150,6 +151,22 @@ public class PushPlugin extends CordovaPlugin {
 
     return result;
   }
+
+  @override
+  public void onRegistrationSuccess(String registrationId){
+      PluginResult success =
+          new PluginResult(PluginResult.Status.OK, registrationId);
+      success.setKeepCallback(false);
+      this.registrationCallback.sendPluginResult(success);
+  }
+
+    @override
+    public void onRegistrationFailure(String errorId){
+        PluginResult success =
+            new PluginResult(PluginResult.Status.ERROR, errorId);
+        success.setKeepCallback(false);
+        this.registrationCallback.sendPluginResult(success);
+    }
 
   private boolean handleUnRegister(JSONArray data, CallbackContext callbackContext) {
     Log.v(TAG, "handleUnRegister() -> data: " + data);

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -4,6 +4,7 @@ import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.LOG;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -34,6 +35,8 @@ public class PushPlugin extends CordovaPlugin {
 
   public void initialize(CordovaInterface cordova, CordovaWebView webView) {
     super.initialize(cordova, webView);
+
+    LOG.setLogLevel(LOG.VERBOSE);
 
     readSenderIdFromCordovaConfig();
   }

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -132,10 +132,11 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
 
         this.registrationCallback.sendPluginResult(temp);
 
-        //this.cordova.getThreadPool()
-        //    .execute(new RegistrationRunnable(data,this));
+        this.cordova.getThreadPool()
+            .execute(new RegistrationRunnable(data,this));
 
-        result = handleRegister(data);
+        //result = handleRegister(data);
+        result = true;
     }
     else if (ON_MESSAGE_FOREGROUND.equals(action)) {
 
@@ -175,13 +176,11 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
             + " callBack "
             + this.registrationCallback.getCallbackId());
 
-      Log.v(TAG, "CallbackContext Finished? "
-            + this.registrationCallback.isFinished());
-
-
-      Log.v(TAG, "CallbackContext is changing threads? "
-            + this.registrationCallback.isChangingThreads());
-
+      PluginResult success
+          = new PluginResult(PluginResult.Status.OK, registrationId);
+      success.setKeepCallback(false);
+      this.registrationCallback.sendPluginResult(success);
+      /*
       this.cordova.getActivity().runOnUiThread(new Runnable(){
               public void run(){
                   PushPlugin.this.webView.setNetworkAvailable(true);
@@ -191,7 +190,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
                   success.setKeepCallback(false);
                   PushPlugin.this.registrationCallback.sendPluginResult(success);
               };
-          });
+              });*/
   }
 
 
@@ -207,12 +206,12 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
             + " callBack "
             + this.registrationCallback.getCallbackId());
 
-      Log.v(TAG, "CallbackContext Finished? "
-            + this.registrationCallback.isFinished());
+      PluginResult error
+          = new PluginResult(PluginResult.Status.ERROR, errorId);
+      error.setKeepCallback(false);
+      this.registrationCallback.sendPluginResult(error);
 
-      Log.v(TAG, "CallbackContext is changing threads? "
-            + this.registrationCallback.isChangingThreads());
-
+      /*
       this.cordova.getActivity().runOnUiThread(new Runnable(){
               public void run(){
                   PushPlugin.this.webView.setNetworkAvailable(true);
@@ -222,7 +221,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
                   success.setKeepCallback(false);
                   PushPlugin.this.registrationCallback.sendPluginResult(success);
               };
-          });
+              }); */
 
       //this.webView.setNetworkAvailable(true);
 

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -4,6 +4,7 @@ import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.PluginResult;
 import org.apache.cordova.LOG;
 import org.json.JSONArray;
 import org.json.JSONObject;

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -87,7 +87,7 @@ public class PushPlugin extends CordovaPlugin {
     }
     catch (Exception e) {
       Log.e(TAG, "execute: Got JSON Exception " + e.getMessage());
-      callbackContext.error(e.getMessage());
+      this.registrationCallback.error(e.getMessage());
       return false;
     }
   }

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -64,7 +64,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
     return this.cordova.getActivity().getApplicationContext();
   }
     @Override
-    private boolean handleRegister(JSONArray data) {
+    public boolean handleRegister(JSONArray data) {
     try {
 
         //Log.v(TAG,

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -4,6 +4,7 @@ import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.CordovaWebViewImpl;
 import org.apache.cordova.PluginResult;
 import org.apache.cordova.LOG;
 import org.json.JSONArray;
@@ -174,10 +175,14 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
       Log.v(TAG, "CallbackContext Finished? "
             + this.registrationCallback.isFinished());
 
+
       Log.v(TAG, "CallbackContext is changing threads? "
             + this.registrationCallback.isChangingThreads());
 
-      Log.v(TAG, "WebView initialized? " + this.webView.isInitialized());
+      CordovaWebViewImpl wvi =
+          (CordovaWebViewImpl)this.webView;
+
+      Log.v(TAG, "WebView initialized? " + wvi.isInitialized());
 
       PluginResult success =
           new PluginResult(PluginResult.Status.OK, registrationId);
@@ -200,7 +205,10 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
       Log.v(TAG, "CallbackContext is changing threads? "
             + this.registrationCallback.isChangingThreads());
 
-      Log.v(TAG, "WebView initialized? " + this.webView.isInitialized());
+      CordovaWebViewImpl wvi =
+          (CordovaWebViewImpl)this.webView;
+
+      Log.v(TAG, "WebView initialized? " + wvi.isInitialized());
 
       PluginResult error =
           new PluginResult(PluginResult.Status.ERROR, errorId);

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -33,27 +33,21 @@ public class PushPlugin extends CordovaPlugin {
 
   public static final String GCM_SENDER_ID = "gcm_senderid";
 
-  private static NotificationService service;
-
   public void initialize(CordovaInterface cordova, CordovaWebView webView) {
     super.initialize(cordova, webView);
 
     LOG.setLogLevel(LOG.VERBOSE);
 
-    Context appContext = getApplicationContext();
-
-    service = NotificationService.getInstance(appContext);
-
-    readSenderIdFromCordovaConfig(service);
-
-    Log.v(TAG, "Initialized w/ Context: " + appContext.toString());
+    readSenderIdFromCordovaConfig();
   }
 
-  private void readSenderIdFromCordovaConfig(NotificationService service) {
+  private void readSenderIdFromCordovaConfig() {
     Bundle extras = cordova.getActivity().getIntent().getExtras();
     if(extras.containsKey(GCM_SENDER_ID)) {
       String senderID = extras.getString(GCM_SENDER_ID);
-      service.setSenderID(senderID);
+      NotificationService
+      .getInstance(getApplicationContext())
+      .setSenderID(senderID);
     }
   }
 
@@ -74,7 +68,7 @@ public class PushPlugin extends CordovaPlugin {
 
       Context appContext = getApplicationContext();
 
-      //NotificationService service = NotificationService.getInstance(appContext);
+      NotificationService service = NotificationService.getInstance(appContext);
 
       if(senderID != null && senderID.trim().length() > 0) {
         service.setSenderID(senderID);
@@ -114,14 +108,19 @@ public class PushPlugin extends CordovaPlugin {
     boolean result = false;
 
     if (REGISTER.equals(action)) {
+
         Log.v(TAG, "handleRegister -> data: " + data);
+
+        PluginResult temp = new PluginResult(PluginResult.Status.NO_RESULT);
+
+        temp.setKeepCallback(true);
+
+        callbackContext.sendPluginResult(temp);
+
         this.cordova.getThreadPool()
             .execute(new RegistrationRunnable(data, callbackContext));
 
         result = true;
-
-
-            //result = handleRegister(data, callbackContext);
     }
     else if (ON_MESSAGE_FOREGROUND.equals(action)) {
 
@@ -150,9 +149,9 @@ public class PushPlugin extends CordovaPlugin {
   private boolean handleUnRegister(JSONArray data, CallbackContext callbackContext) {
     Log.v(TAG, "handleUnRegister() -> data: " + data);
 
-    //NotificationService
-    //.getInstance(getApplicationContext())
-    service.unRegister();
+    NotificationService
+    .getInstance(getApplicationContext())
+    .unRegister();
 
     callbackContext.success();
     return true;
@@ -161,9 +160,9 @@ public class PushPlugin extends CordovaPlugin {
   private boolean handleOnMessageForeground(JSONArray data, CallbackContext callbackContext) {
     Log.v(TAG, "handleOnMessageForeground() -> data: " + data);
 
-    //NotificationService
-    //.getInstance(getApplicationContext())
-    service.addNotificationForegroundCallBack(this.webView, callbackContext);
+    NotificationService
+    .getInstance(getApplicationContext())
+    .addNotificationForegroundCallBack(this.webView, callbackContext);
 
     return true;
   }
@@ -171,9 +170,9 @@ public class PushPlugin extends CordovaPlugin {
   private boolean handleOnMessageBackground(JSONArray data, CallbackContext callbackContext) {
     Log.v(TAG, "handleOnMessageBackground() -> data: " + data);
 
-    //NotificationService
-    //.getInstance(getApplicationContext())
-    service.addNotificationBackgroundCallBack(this.webView, callbackContext);
+    NotificationService
+    .getInstance(getApplicationContext())
+    .addNotificationBackgroundCallBack(this.webView, callbackContext);
 
     return true;
   }
@@ -184,9 +183,9 @@ public class PushPlugin extends CordovaPlugin {
 
     Log.v(TAG, "onPause() -> webView: " + webView);
 
-    //NotificationService
-    //.getInstance(getApplicationContext())
-    service.setForeground(false);
+    NotificationService
+    .getInstance(getApplicationContext())
+    .setForeground(false);
   }
 
   @Override
@@ -195,9 +194,9 @@ public class PushPlugin extends CordovaPlugin {
 
     Log.v(TAG, "onResume() -> webView: " + webView);
 
-    //NotificationService
-    //.getInstance(getApplicationContext())
-    service.setForeground(true);
+    NotificationService
+    .getInstance(getApplicationContext())
+    .setForeground(true);
   }
 
 
@@ -205,9 +204,9 @@ public class PushPlugin extends CordovaPlugin {
 
     Log.v(TAG, "onDestroy() -> webView: " + webView);
 
-    //NotificationService
-    //.getInstance(getApplicationContext())
-    service.removeWebView(this.webView);
+    NotificationService
+    .getInstance(getApplicationContext())
+    .removeWebView(this.webView);
 
     super.onDestroy();
   }

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -158,12 +158,16 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
       callbackContext.error("Invalid action : " + action);
     }
 
+    Log.v(TAG, "Exiting Exec method: " + this.toString());
     return result;
   }
 
   @Override
   public void onRegistrationSuccess(String registrationId){
-      Log.v(TAG, "Registration Success called: " + registrationId);
+      Log.v(TAG, "Registration Success called: "
+            + registrationId
+            + " for instance "
+            + this.toString());
       PluginResult success =
           new PluginResult(PluginResult.Status.OK, registrationId);
       success.setKeepCallback(false);
@@ -172,7 +176,10 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
 
   @Override
   public void onRegistrationFailure(String errorId){
-      Log.v(TAG, "Registration Failure called: " + errorId);
+      Log.v(TAG, "Registration Failure called: "
+            + errorId
+            + " for instance "
+            + this.toString());
       PluginResult success =
           new PluginResult(PluginResult.Status.ERROR, errorId);
       success.setKeepCallback(false);

--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -63,9 +63,12 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
   private Context getApplicationContext() {
     return this.cordova.getActivity().getApplicationContext();
   }
-
+    @Override
     private boolean handleRegister(JSONArray data) {
     try {
+
+        //Log.v(TAG,
+        //      "Handling registration on separate thread ->" + data.toString());
 
       JSONObject jo = data.getJSONObject(0);
 
@@ -95,13 +98,17 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
 
     class RegistrationRunnable implements Runnable{
         private JSONArray data;
+        private AsyncRegistrationInterface iFace;
 
-        RegistrationRunnable(JSONArray data){
+        RegistrationRunnable(JSONArray data, AsyncRegistrationInterface iFace){
             this.data = data;
+            this.iFace = iFace;
+
+            Log.v(TAG, "iFace = " + iFace.toString());
         }
 
         public void run(){
-            PushPlugin.this.handleRegister(this.data);
+            iFace.handleRegister(this.data);
         }
     }
 
@@ -114,6 +121,8 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
 
         Log.v(TAG, "handleRegister -> data: " + data);
 
+        Log.v(TAG, "PushPlugin == " + this.toString());
+
         //need to keep a reference hanging around to the callback
         this.registrationCallback = callbackContext;
 
@@ -123,10 +132,10 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
 
         this.registrationCallback.sendPluginResult(temp);
 
-        this.cordova.getThreadPool()
-            .execute(new RegistrationRunnable(data));
+        //this.cordova.getThreadPool()
+        //    .execute(new RegistrationRunnable(data,this));
 
-        result = true;
+        result = handleRegister(data);
     }
     else if (ON_MESSAGE_FOREGROUND.equals(action)) {
 
@@ -154,6 +163,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
 
   @Override
   public void onRegistrationSuccess(String registrationId){
+      Log.v(TAG, "Registration Success called: " + registrationId);
       PluginResult success =
           new PluginResult(PluginResult.Status.OK, registrationId);
       success.setKeepCallback(false);
@@ -162,6 +172,7 @@ public class PushPlugin extends CordovaPlugin implements AsyncRegistrationInterf
 
   @Override
   public void onRegistrationFailure(String errorId){
+      Log.v(TAG, "Registration Failure called: " + errorId);
       PluginResult success =
           new PluginResult(PluginResult.Status.ERROR, errorId);
       success.setKeepCallback(false);

--- a/www/PushNotification.js
+++ b/www/PushNotification.js
@@ -4,8 +4,8 @@
 
   // Call this to register for push notifications. Content of [options] depends on whether we are working with APNS (iOS) or GCM (Android)
   PushNotification.prototype.register = function(successCallback, errorCallback, options) {
-      errorCallback = errorCallback || function() {
-          console.log("Registration Failure");
+      errorCallback = errorCallback || function(err) {
+          alert("Registration Failure " + err);
       };
 
     if (typeof errorCallback != "function")  {

--- a/www/PushNotification.js
+++ b/www/PushNotification.js
@@ -1,11 +1,12 @@
-
   var exec = require('cordova/exec');
 
   var PushNotification = function() {};
 
   // Call this to register for push notifications. Content of [options] depends on whether we are working with APNS (iOS) or GCM (Android)
   PushNotification.prototype.register = function(successCallback, errorCallback, options) {
-    errorCallback = errorCallback || function() {};
+      errorCallback = errorCallback || function() {
+          console.log("Registration Failure");
+      };
 
     if (typeof errorCallback != "function")  {
       console.log("PushNotification.register failure: failure parameter not a function");

--- a/www/PushNotification.js
+++ b/www/PushNotification.js
@@ -4,9 +4,7 @@
 
   // Call this to register for push notifications. Content of [options] depends on whether we are working with APNS (iOS) or GCM (Android)
   PushNotification.prototype.register = function(successCallback, errorCallback, options) {
-      errorCallback = errorCallback || function(err) {
-          alert("Registration Failure " + err);
-      };
+    errorCallback = errorCallback || function() {};
 
     if (typeof errorCallback != "function")  {
       console.log("PushNotification.register failure: failure parameter not a function");


### PR DESCRIPTION
keeps callbackContext around for async registration process and handles registration failures by calling the appropriate error callback passed in to exec. Also, gets rid of exec() warning by moving registration off of the WebCore thread.  It's asynchronous, so calling that code on the WebCore thread is a waste of time.  This is branched off of the next branch.  I added a comment in plugin.xml related to issue #15.  That is not fixed on this branch as I have no control over that from the plugin AFAIK.  It should also be noted that I am still seeing a failure of either callback (success or error) to fire in steroids intermittently.   I can trace the callbacks all the way through the native code, and the PluginResult is sent, but they intermittently do not get evaluated on the javascript side.  What version of cordova-android is being used?  and is there any debugging I can do on the jsMessageQueue or BridgeMode to figure out where these messages are getting dropped?  I see no error messages in the device log that would lead me to believe an exception is being thrown.  This bug is occurring   with the current next branch and persists on this PR.  Any help in figuring out what is going on there would be greatly appreciated.  If you can point me in the right direction, I am happy help. 